### PR TITLE
Python3 support - changed model SubfieldBase metaclass syntax.

### DIFF
--- a/thecut/durationfield/models.py
+++ b/thecut/durationfield/models.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
+from django.utils.six import with_metaclass
 from isodate.isoerror import ISO8601Error
 import isodate
 
@@ -15,7 +16,7 @@ except ImportError:
     add_introspection_rules = None
 
 
-class ISO8601DurationField(models.Field):
+class ISO8601DurationField(with_metaclass(models.SubfieldBase, models.Field)):
     """Store and retrieve ISO 8601 formatted durations.
 
     """

--- a/thecut/durationfield/models.py
+++ b/thecut/durationfield/models.py
@@ -23,8 +23,6 @@ class ISO8601DurationField(with_metaclass(models.SubfieldBase, models.Field)):
 
     description = _("A duration of time (ISO 8601 format)")
 
-    __metaclass__ = models.SubfieldBase
-
     default_error_messages = {
         'invalid': _("This value must be in ISO 8601 Duration format."),
         'unknown_type': _("The value's type could not be converted"),


### PR DESCRIPTION
Using this fix, I use RelativeDeltaField in a python3 project without any problem.
