### PR TITLE
Django 1.10 support

### DIFF
--- a/thecut/durationfield/models.py
+++ b/thecut/durationfield/models.py
@@ -10,12 +10,6 @@ from isodate.isoerror import ISO8601Error
 import isodate
 
 
-try:
-    from south.modelsinspector import add_introspection_rules
-except ImportError:
-    add_introspection_rules = None
-
-
 class ISO8601DurationField(models.Field):
     """Store and retrieve ISO 8601 formatted durations.
 
@@ -117,8 +111,3 @@ class RelativeDeltaField(ISO8601DurationField):
         val = self._get_val_from_obj(obj)
         s = self.get_prep_value(val)
         return '' if s is None else s
-
-if add_introspection_rules:
-    add_introspection_rules(
-        [], ['^thecut\.durationfield\.models\.ISO8601DurationField',
-             '^thecut\.durationfield\.models\.RelativeDeltaField'])

--- a/thecut/durationfield/models.py
+++ b/thecut/durationfield/models.py
@@ -6,7 +6,6 @@ from dateutil.relativedelta import relativedelta
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
-from django.utils.six import with_metaclass
 from isodate.isoerror import ISO8601Error
 import isodate
 
@@ -17,7 +16,7 @@ except ImportError:
     add_introspection_rules = None
 
 
-class ISO8601DurationField(with_metaclass(models.SubfieldBase, models.Field)):
+class ISO8601DurationField(models.Field):
     """Store and retrieve ISO 8601 formatted durations.
 
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-	py26-django14, py26-django15, py26-django16,
-	py27-django14, py27-django15, py27-django16, py27-django17,
-	py34-django15, py34-django16, py34-django17
+     py27-django18, py27-django19, py27-django110,
+     py34-django18, py34-django19, py34-django110,
+     py35-django18, py35-django19, py35-django110
 
 [testenv]
 setenv =
@@ -11,62 +11,56 @@ commands = python runtests.py
 deps =
     -r{toxinidir}/requirements-test.txt
 
-[testenv:py26-django14]
-basepython = python2.6
-deps =
-     django>=1.4, <1.5
-     {[testenv]deps}
-
-[testenv:py26-django15]
-basepython = python2.6
-deps =
-     django>=1.5, <1.6
-     {[testenv]deps}
-
-[testenv:py26-django16]
-basepython = python2.6
-deps =
-     django>=1.6, <1.7
-     {[testenv]deps}
-
-[testenv:py27-django14]
+[testenv:py27-django18]
 basepython = python2.7
 deps =
-     django>=1.4, <1.5
+     django>=1.8, <1.9
      {[testenv]deps}
 
-[testenv:py27-django15]
+[testenv:py27-django19]
 basepython = python2.7
 deps =
-     django>=1.5, <1.6
+     django>=1.9, <1.10
      {[testenv]deps}
 
-[testenv:py27-django16]
+[testenv:py27-django110]
 basepython = python2.7
 deps =
-     django>=1.6, <1.7
+     django>=1.10, <1.11
      {[testenv]deps}
 
-[testenv:py27-django17]
-basepython = python2.7
-deps =
-     {[testenv]deps}
-     https://www.djangoproject.com/download/1.7c2/tarball/
-
-[testenv:py34-django15]
+[testenv:py34-django18]
 basepython = python3.4
 deps =
+     django>=1.8, <1.9
      {[testenv]deps}
-     django>=1.5, <1.6
 
-[testenv:py34-django16]
+[testenv:py34-django19]
 basepython = python3.4
 deps =
+     django>=1.9, <1.10
      {[testenv]deps}
-     django>=1.6, <1.7
 
-[testenv:py34-django17]
+[testenv:py34-django110]
 basepython = python3.4
 deps =
+     django>=1.10, <1.11
      {[testenv]deps}
-     https://www.djangoproject.com/download/1.7c1/tarball/
+
+[testenv:py35-django18]
+basepython = python3.5
+deps =
+     django>=1.8, <1.9
+     {[testenv]deps}
+
+[testenv:py35-django19]
+basepython = python3.5
+deps =
+     django>=1.9, <1.10
+     {[testenv]deps}
+
+[testenv:py35-django110]
+basepython = python3.5
+deps =
+     django>=1.10, <1.11
+     {[testenv]deps}


### PR DESCRIPTION
Since Django < 1.8 has reached EOL, I
- removed SubfieldBase ([doc](https://docs.djangoproject.com/en/1.8/howto/custom-model-fields/#converting-values-to-python-objects))
- removed South refs
- removed 2.6 support (1.8 only supports python >= 2.7)
- added 3.5 in test matrix
